### PR TITLE
Fix caret position

### DIFF
--- a/InputElement.js
+++ b/InputElement.js
@@ -556,7 +556,7 @@ var InputElement = React.createClass({
         }
         event.preventDefault();
         if (caretPos < maskLen && caretPos > prefixLen) {
-            caretPos = this.getRightEditablePos(caretPos);
+            caretPos = this.getRightEditablePos(caretPos) || caretPos;
         }
         this.setCaretPos(caretPos);
     },


### PR DESCRIPTION
If you enter char after last `9` in mask `(999)` then `getRightEditablePos` will return `null` and caret will be reseted.