### PR TITLE
Add babelrc to npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
If react-input-mask was not ignored for babel 6, babel will complain about `.babelrc` (which has babel 5 format).