### PR TITLE
If formatChars is null, use default

### DIFF
--- a/InputElement.js
+++ b/InputElement.js
@@ -15,7 +15,9 @@ class InputElement extends React.Component {
         super(props);
 
         this.hasValue = props.value != null;
-        this.charsRules = "formatChars" in props ? props.formatChars : this.defaultCharsRules;
+        this.charsRules = props.formatChars != null 
+            ? props.formatChars
+            : this.defaultCharsRules;
 
         var mask = this.parseMask(props.mask);
         var defaultValue = props.defaultValue != null
@@ -463,7 +465,9 @@ class InputElement extends React.Component {
 
     componentWillReceiveProps = (nextProps) => {
         this.hasValue = this.props.value != null;
-        this.charsRules = "formatChars" in nextProps ? nextProps.formatChars : this.defaultCharsRules;
+        this.charsRules = props.formatChars != null 
+            ? props.formatChars
+            : this.defaultCharsRules;
 
         var oldMask = this.mask;
         var mask = this.parseMask(nextProps.mask);


### PR DESCRIPTION
Currently if you pass null as formatChars, it uses that instead of the defaultCharRules.

Passing null is a standard react practice that basically means "ignore this prop", and should be respected.