### PR TITLE
Calling 'this.props.onPaste' callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -580,6 +580,13 @@ class InputElement extends React.Component {
   }
 
   onPaste = (event) => {
+    if (typeof this.props.onPaste === 'function') {
+      this.props.onPaste(event);
+      if (event.defaultPrevented) {
+        return;
+      }
+    }
+
     if (this.isAndroidBrowser) {
       this.pasteSelection = this.getSelection();
       this.setInputValue('');


### PR DESCRIPTION
The problem I'm trying to solve with this PR is that the callback function passed in `onPaste` prop is never executed. It's a problem in my opinion, since It's necessary to handle `onPaste` event when you want to prevent pasting in the text field.

Any suggestions are welcome.
Thanks.


