### PR TITLE
Include next permanent char(s) when maskChar is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -315,6 +315,9 @@ class InputElement extends React.Component {
           : this.getLeftEditablePos(cursorPos - 1);
 
         if (editablePos !== null) {
+          if (!maskChar) {
+            value = value.substr(0, getFilledLength(this.maskOptions, value));
+          }
           value = clearRange(this.maskOptions, value, editablePos, 1);
           cursorPos = editablePos;
         }

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -63,10 +63,13 @@ export function formatValue(maskOptions, value) {
 
   if (!maskChar) {
     value = insertString(maskOptions, '', value, 0);
-    value = value.slice(0, getFilledLength(maskOptions, value));
 
     if (value.length < prefix.length) {
       value = prefix;
+    }
+
+    while (value.length < mask.length && isPermanentChar(maskOptions, value.length)) {
+      value += mask[value.length];
     }
 
     return value;
@@ -94,6 +97,13 @@ export function clearRange(maskOptions, value, start, len) {
   var arrayValue = value.split('');
 
   if (!maskChar) {
+    // remove any permanent chars after clear range, they will be added back by foramtValue
+    for (var i = end; i < arrayValue.length; i++) {
+      if (isPermanentChar(maskOptions, i)) {
+        arrayValue[i] = '';
+      }
+    }
+
     start = Math.max(prefix.length, start);
     arrayValue.splice(start, end - start);
     value = arrayValue.join('');

--- a/tests/input/input.js
+++ b/tests/input/input.js
@@ -110,16 +110,11 @@ describe('Input', () => {
     <Input mask="+4\9 99 9\99 99" maskChar={null} />, (input, inputNode) => {
       inputNode.focus();
       TestUtils.Simulate.focus(inputNode);
-      expect(inputNode.value).to.equal('+49 ');
+      
 
-      inputNode.value = '+49 12 394';
-      input.setCursorPos(10);
+      inputNode.value = '+49 12 3';
       TestUtils.Simulate.change(inputNode);
-
-      input.setCursorPos(10);
-      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
-      TestUtils.Simulate.change(inputNode);
-      expect(inputNode.value).to.equal('+49 12 3');
+      expect(inputNode.value).to.equal('+49 12 39');
     }));
 
   it('alwaysShowMask', createInput(
@@ -213,13 +208,14 @@ describe('Input', () => {
     <Input mask="**** **** **** ****" maskChar={null} />, (input, inputNode) => {
       inputNode.focus();
       TestUtils.Simulate.focus(inputNode);
+      expect(inputNode.value).to.equal('');
 
       input.setCursorPos(0);
-      inputNode.value = 'aaaa';
-      input.setCursorPos(4);
+      inputNode.value = 'aaa';
+      input.setCursorPos(3);
       TestUtils.Simulate.change(inputNode);
-      expect(inputNode.value).to.equal('aaaa');
-      expect(input.getCursorPos()).to.equal(4);
+      expect(inputNode.value).to.equal('aaa');
+      expect(input.getCursorPos()).to.equal(3);
 
       inputNode.value = 'aaaaa';
       input.setCursorPos(5);
@@ -369,14 +365,14 @@ describe('Input', () => {
     }));
 
   it('Backspace single character cursor position without maskChar', createInput(
-    <Input mask="+7 (999) 999 99 99" defaultValue="7495315645" maskChar={null} />, (input, inputNode) => {
+    <Input mask="+7 (999) 999 99 99" defaultValue="749531564" maskChar={null} />, (input, inputNode) => {
       inputNode.focus();
       TestUtils.Simulate.focus(inputNode);
 
-      input.setCursorPos(17);
+      input.setCursorPos(16);
       TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
       TestUtils.Simulate.change(inputNode);
-      expect(input.getCursorPos()).to.equal(15);
+      expect(input.getCursorPos()).to.equal(14);
     }));
 
   it('Backspace range', createInput(
@@ -400,6 +396,92 @@ describe('Input', () => {
       TestUtils.Simulate.change(inputNode);
       expect(input.getCursorPos()).to.equal(1);
     }));
+
+  it('Backspace single character with escaped characters without maskChar', createInput(
+    <Input mask="+4\9 99 9\99 99" defaultValue="+49 12 394" maskChar={null} />, (input, inputNode) => {
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+
+      input.setCursorPos(10);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 12 39');
+
+      input.setCursorPos(9);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 12 ');
+
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+      inputNode.value = '+49 12 39';
+      TestUtils.Simulate.change(inputNode);
+      input.setCursorPos(6);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 13 ');
+    }));
+
+  it('Backspace single character with escaped characters without maskChar cursor position', createInput(
+    <Input mask="+4\9 99 9\99 99" defaultValue="+49 12 394" maskChar={null} />, (input, inputNode) => {
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+
+      input.setCursorPos(10);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+      TestUtils.Simulate.change(inputNode);
+      expect(input.getCursorPos()).to.equal(9);
+
+      input.setCursorPos(9);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+      TestUtils.Simulate.change(inputNode);
+      expect(input.getCursorPos()).to.equal(7);
+
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+      inputNode.value = '+49 12 39';
+      TestUtils.Simulate.change(inputNode);
+      input.setCursorPos(6);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+      TestUtils.Simulate.change(inputNode);
+      expect(input.getCursorPos()).to.equal(5);
+    }));
+
+  it('Backspace range with escaped characters without maskChar', createInput(
+    <Input mask="+4\9 99 9\99 99" defaultValue="+49 12 394" maskChar={null} />, (input, inputNode) => {
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+
+      input.setSelection(4, 2);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 34 ');
+
+      inputNode.value = '+49 12 394 5';
+      TestUtils.Simulate.change(inputNode);
+      input.setSelection(4, 2);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 34 59');
+    }));
+
+    it('Backspace range with escaped characters without maskChar cursor position', createInput(
+      <Input mask="+4\9 99 9\99 99" defaultValue="+49 12 394" maskChar={null} />, (input, inputNode) => {
+        inputNode.focus();
+        TestUtils.Simulate.focus(inputNode);
+  
+        input.setSelection(4, 2);
+        TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+        TestUtils.Simulate.change(inputNode);
+        expect(input.getCursorPos()).to.equal(4);
+  
+        inputNode.value = '+49 12 394 5';
+        TestUtils.Simulate.change(inputNode);
+        input.setSelection(4, 2);
+        TestUtils.Simulate.keyDown(inputNode, { key: 'Backspace' });
+        TestUtils.Simulate.change(inputNode);
+        expect(input.getCursorPos()).to.equal(4);
+      }));
 
   it('Delete single character', createInput(
     <Input mask="+7 (999) 999 99 99" defaultValue="74953156454" />, (input, inputNode) => {
@@ -452,6 +534,92 @@ describe('Input', () => {
       TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
       TestUtils.Simulate.change(inputNode);
       expect(inputNode.value).to.equal('+7 (___) _15 64 54');
+    }));
+
+  it('Delete single character with escaped characters without maskChar', createInput(
+    <Input mask="+4\9 99 9\99 99" defaultValue="+49 12 394" maskChar={null} />, (input, inputNode) => {
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+
+      input.setCursorPos(9);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 12 39');
+
+      input.setCursorPos(7);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 12 ');
+
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+      inputNode.value = '+49 12 39';
+      TestUtils.Simulate.change(inputNode);
+      input.setCursorPos(5);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 13 ');
+    }));
+
+  it('Delete single character with escaped characters without maskChar cursor position', createInput(
+    <Input mask="+4\9 99 9\99 99" defaultValue="+49 12 394" maskChar={null} />, (input, inputNode) => {
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+
+      input.setCursorPos(9);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(input.getCursorPos()).to.equal(9);
+
+      input.setCursorPos(7);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(input.getCursorPos()).to.equal(7);
+
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+      inputNode.value = '+49 12 39';
+      TestUtils.Simulate.change(inputNode);
+      input.setCursorPos(5);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(input.getCursorPos()).to.equal(5);
+    }));
+
+  it('Delete range with escaped characters without maskChar', createInput(
+    <Input mask="+4\9 99 9\99 99" defaultValue="+49 12 394" maskChar={null} />, (input, inputNode) => {
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+
+      input.setSelection(4, 2);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 34 ');
+
+      inputNode.value = '+49 12 394 5';
+      TestUtils.Simulate.change(inputNode);
+      input.setSelection(4, 2);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(inputNode.value).to.equal('+49 34 59');
+    }));
+
+  it('Delete range with escaped characters without maskChar cursor position', createInput(
+    <Input mask="+4\9 99 9\99 99" defaultValue="+49 12 394" maskChar={null} />, (input, inputNode) => {
+      inputNode.focus();
+      TestUtils.Simulate.focus(inputNode);
+
+      input.setSelection(4, 2);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(input.getCursorPos()).to.equal(4);
+
+      inputNode.value = '+49 12 394 5';
+      TestUtils.Simulate.change(inputNode);
+      input.setSelection(4, 2);
+      TestUtils.Simulate.keyDown(inputNode, { key: 'Delete' });
+      TestUtils.Simulate.change(inputNode);
+      expect(input.getCursorPos()).to.equal(4);
     }));
 
   it('Mask change', createInput(
@@ -596,5 +764,20 @@ describe('Input', () => {
         value: '54321'
       });
       expect(inputNode.value).to.equal('54321');
+    }));
+
+  it('Should show next permanent char when maskChar is null', createInput(
+    <Input mask="99/99/9999" value="01" maskChar={null} />, (input, inputNode) => {
+      expect(inputNode.value).to.equal('01/');
+    }));
+
+  it('Should show all next consecutive permanent char when maskChar is null', createInput(
+    <Input mask="99---99" value="01" maskChar={null} />, (input, inputNode) => {
+      expect(inputNode.value).to.equal('01---');
+    }));
+
+  it('Should show trailing permanent char when maskChar is null', createInput(
+    <Input mask="99%" value="10" maskChar={null} />, (input, inputNode) => {
+      expect(inputNode.value).to.equal('10%');
     }));
 });


### PR DESCRIPTION
Related to https://github.com/sanniassin/react-input-mask/issues/59, this appears to be happening again.  

Believe I covered all the fun edge cases when using escape characters in a mask. Happy to add more tests if you know of others.

This might also resolve #61. It does when maskChar is null but not sure about other maskChar values.