### PR TITLE
Allow user to define a ref function on the internal input

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,14 @@ class PhoneInput extends React.Component {
 }
 ```
 
+### `userRef` : `function`
+
+Attaches a `ref` handler to the `<input>` tag. In case you need to save a reference to manage focus, etc.
+
+## Example
+```jsx
+<InputMask userRef={ref => (this.input = ref)} />
+```
+
 ## Thanks
 Thanks to [BrowserStack](https://www.browserstack.com/) for the help with testing on real devices

--- a/src/index.js
+++ b/src/index.js
@@ -514,7 +514,15 @@ class InputElement extends React.Component {
   }
 
   render() {
-    var { mask, alwaysShowMask, maskChar, formatChars, ...props } = this.props;
+    var { mask, alwaysShowMask, maskChar, formatChars, userRef, ...props } = this.props;
+
+    var assignRef = ref => {
+      if (typeof userRef === 'function') {
+        userRef(ref);
+      }
+
+      this.input = ref;
+    }
 
     if (this.maskOptions.mask) {
       if (!props.disabled && !props.readOnly) {
@@ -529,7 +537,7 @@ class InputElement extends React.Component {
       }
     }
 
-    return <input ref={ref => this.input = ref} {...props} onFocus={this.onFocus} onBlur={this.onBlur} />;
+    return <input ref={assignRef} {...props} onFocus={this.onFocus} onBlur={this.onBlur} />;
   }
 }
 


### PR DESCRIPTION
Currently there is no way to pass through a `ref` function to the input, as the InputMask internally sets its own ref.

This allows a user to set an additional custom `ref` function on the internal input tag.