### PR TITLE
Refactor babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,18 +1,13 @@
 {
+  "presets": [
+    ["@babel/preset-env", { "modules": false, "loose": true }],
+    "@babel/preset-react",
+    ['@babel/preset-stage-3']
+  ],
   "env": {
-    "rollup": {
-      "exclude": "node_modules/**",
-      "presets": [
-        ["@babel/preset-es2015", { "modules": false, "loose": true }],
-        "@babel/preset-react",
-        ['@babel/preset-stage-2', { decoratorsLegacy: true }]
-      ]
-    },
-    "tests": {
-      "presets": [
-        ["@babel/preset-es2015", { "loose": true }],
-        "@babel/preset-react",
-        ['@babel/preset-stage-2', { decoratorsLegacy: true }]
+    "test": {
+      "plugins": [
+        "@babel/transform-modules-commonjs"
       ]
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/react-input-mask.js": {
-    "bundled": 31943,
-    "minified": 12411,
-    "gzipped": 4260
+    "bundled": 31203,
+    "minified": 11998,
+    "gzipped": 4144
   },
   "lib/index.js": {
-    "bundled": 30149,
-    "minified": 13823,
-    "gzipped": 4336
+    "bundled": 29447,
+    "minified": 13354,
+    "gzipped": 4215
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,16 @@
         "@babel/types": "7.0.0-beta.46"
       }
     },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.46.tgz",
+      "integrity": "sha512-ZCQ62KqFC5R3NPe5ug9pVqIHYJNup8UdEbE4IXw+s7zr4D/7AsKSt3pXA+FbML5AnQXeCSOuUWioggGmKuDV5g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.46",
+        "@babel/types": "7.0.0-beta.46"
+      }
+    },
     "@babel/helper-builder-react-jsx": {
       "version": "7.0.0-beta.46",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.46.tgz",
@@ -105,6 +115,16 @@
         "@babel/helper-function-name": "7.0.0-beta.46",
         "@babel/types": "7.0.0-beta.46",
         "lodash": "4.17.10"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.46.tgz",
+      "integrity": "sha512-SW1OUmx2fC2SqL7+vF1N72FITbPuEWGdr/Gm7I3Vqs8p8T1dfGwB9YFsD+tTpfagKXVMiCCuQ06+G0FB8uxg6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "7.0.0-beta.46",
+        "@babel/types": "7.0.0-beta.46"
       }
     },
     "@babel/helper-function-name": {
@@ -295,47 +315,6 @@
         "@babel/plugin-syntax-class-properties": "7.0.0-beta.46"
       }
     },
-    "@babel/plugin-proposal-decorators": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.0.0-beta.46.tgz",
-      "integrity": "sha512-2z+ayU1saRWfvHGE9uU+275EGSDQlGf37U2Vs2F9BjN0eUC+JAC96ncq2FuwLLRR8d6rfckzBJNqDNuW8Azaeg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-decorators": "7.0.0-beta.46"
-      }
-    },
-    "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.0.0-beta.46.tgz",
-      "integrity": "sha512-9B7d8NfGZ3F1aKQgINmpc1SAphVgGvKEyw1ppetMpThT6EFWAdW6p1/K6QT7kI+hOo6iKUmUo8sOwD30nWVr9w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-export-namespace-from": "7.0.0-beta.46"
-      }
-    },
-    "@babel/plugin-proposal-function-sent": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-function-sent/-/plugin-proposal-function-sent-7.0.0-beta.46.tgz",
-      "integrity": "sha512-mRkAbYO+uW70bXstzChyf3Tj+39CO4X/+FoPVG7Tb2CmvX5/m4+WPi/5DhW27Gc4zGk6hd90bV6n485JwQYsRw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-wrap-function": "7.0.0-beta.46",
-        "@babel/plugin-syntax-function-sent": "7.0.0-beta.46"
-      }
-    },
-    "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.0.0-beta.46.tgz",
-      "integrity": "sha512-GlT+pFmvWeyiVc05anxwPtewl7P7eBK7x6z9HEBVyzD/vPtsHexN1qwwZmwHBiTkS/1/QXCFr5aPyCgcyUzn9Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-numeric-separator": "7.0.0-beta.46"
-      }
-    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.0.0-beta.46",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.46.tgz",
@@ -354,16 +333,6 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.46",
         "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.46"
-      }
-    },
-    "@babel/plugin-proposal-throw-expressions": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.0.0-beta.46.tgz",
-      "integrity": "sha512-l+YsUx/q/Cigmpy78KD7hLdymt0/jDtHpES2tDX0Af7wMq4Gdi6Ar59Hou/QyP1iG4vV4LvzNa5ieOKTQwm/7w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-throw-expressions": "7.0.0-beta.46"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -395,37 +364,10 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
       }
     },
-    "@babel/plugin-syntax-decorators": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.0.0-beta.46.tgz",
-      "integrity": "sha512-yfgDxx6Vlm/gVGqHtW/rAL5gl8DuNtUqGYAdPaHl5B4GwmqhR/TNmL0mGuovky8Pruh5qTWLxK/NeCzs+p7LpA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
-      }
-    },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.0.0-beta.46",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.46.tgz",
       "integrity": "sha512-D4ek6tZa80NgaTSprPOVxj8vxjChh6UCWgCT/ZvCwAa6CBe3iqUCuOwZQLjU41aDdeuR7C02wxl3rcb25wCRLA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
-      }
-    },
-    "@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.0.0-beta.46.tgz",
-      "integrity": "sha512-g2opDn12R9HhFHq/S6J8qixDNb29WNXNC+kj6Gpk4n3ZX1OCk7qBiyiFplnHUvrPrRA18IcKyPoC2SirLs15vg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
-      }
-    },
-    "@babel/plugin-syntax-function-sent": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-sent/-/plugin-syntax-function-sent-7.0.0-beta.46.tgz",
-      "integrity": "sha512-8XBmvwHwskrIslqqbuwlqcMxWjZlW4E643nM7V5YLECB9EB6ouaifQPK7mUg0R08YzeQpHj+wtR1bwtt845LEg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
@@ -449,15 +391,6 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
       }
     },
-    "@babel/plugin-syntax-numeric-separator": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.0.0-beta.46.tgz",
-      "integrity": "sha512-xLcA7vqeCFDQbpbo0rrJvrTMjnjx2i9WwOkSbw+zXy9M/bmVwGAgLGROVxeuWq1Ou8Ku827DuhCzXgyf5dWvoQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
-      }
-    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.0.0-beta.46",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.46.tgz",
@@ -476,15 +409,6 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
       }
     },
-    "@babel/plugin-syntax-throw-expressions": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.0.0-beta.46.tgz",
-      "integrity": "sha512-JLRBrAfQNxFZrv1K1X9SHwgj+NGDnlaFusKzdxt8E5eraIkujUNu7dVrOJ0Y7silPG3s+47fYxTzxSlRstW9fg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
-      }
-    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.0.0-beta.46",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.46.tgz",
@@ -492,6 +416,17 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.46.tgz",
+      "integrity": "sha512-obykYLqAd3tujTjHYE+dln5+nDhm+R5FmUcxXFr/Mx6LK1NgrTQ9TdPPOcMCD08r8SDljFpMopuz9upN/xJlbw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.46",
+        "@babel/helper-plugin-utils": "7.0.0-beta.46",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.46"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -547,12 +482,33 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
       }
     },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.46.tgz",
+      "integrity": "sha512-5bO0XvTP+2LFDQ9qT/WaXfyieLtqz1yGsfOuq86VXmwX9tDnBnNS6pCHEGFQ866c1HmlNBWtaXttTTnvWkFBkw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.46",
+        "@babel/helper-regex": "7.0.0-beta.46",
+        "regexpu-core": "4.1.3"
+      }
+    },
     "@babel/plugin-transform-duplicate-keys": {
       "version": "7.0.0-beta.46",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.46.tgz",
       "integrity": "sha512-mP2+3QQ+ArIMX98zVYSC9XBzV7A/Pxbz+2hPcEAGVeakFYm5AeTkcVHRQzzA21v4ecl0L5LE1XWX9yeK643CWw==",
       "dev": true,
       "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.46.tgz",
+      "integrity": "sha512-acomgoNW/fwWSmBlhH22C9Eyl1Y/vADBSqzyIRWJGpm4frLhd49QQgKXbRGRHUDxyifXuZDF9+3pRhEmi7/HXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.46",
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
       }
     },
@@ -572,15 +528,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
-      }
-    },
-    "@babel/plugin-transform-instanceof": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0-beta.46.tgz",
-      "integrity": "sha512-yMde/XDsS8ONNoI+QsT3RR/0Lrq5yKYEVZxMxsm+naKN/n1+CiG6sN9USAzF6qy+XC4uRTJ5gpDZu0CtDnh0qA==",
-      "dev": true,
-      "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
       }
     },
@@ -631,6 +578,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "7.0.0-beta.46",
+        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.46.tgz",
+      "integrity": "sha512-VSuIdVFUhlqADj/ymm7NG4BVjGD0sBWWN5sONTLAYzKScGZA58Ys8jSkl1dxeqWnMOEjzo8lTRWxRVvz8HIaMg==",
+      "dev": true,
+      "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.46"
       }
     },
@@ -772,28 +728,39 @@
         "regenerator-runtime": "0.11.1"
       }
     },
-    "@babel/preset-es2015": {
+    "@babel/preset-env": {
       "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/preset-es2015/-/preset-es2015-7.0.0-beta.46.tgz",
-      "integrity": "sha512-4T9AFPRkg6K8OaGeHlOY8UdJz5I03WOpAGGnNwCf4GzXnVuC/fBAnT4yQ1OZYIjabf35jBw6bE1KympDuF8HoQ==",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.46.tgz",
+      "integrity": "sha512-zC+QsTmteh2c1CtjeskvUKsqvRpgwBZxOxTk6p+F3gL6uJszP4OWzffgPrsV2wo9vccppTaCzYMFeiJscnne6g==",
       "dev": true,
       "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.46",
         "@babel/helper-plugin-utils": "7.0.0-beta.46",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.46",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.46",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.46",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.46",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.46",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.46",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.46",
         "@babel/plugin-transform-arrow-functions": "7.0.0-beta.46",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.46",
         "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.46",
         "@babel/plugin-transform-block-scoping": "7.0.0-beta.46",
         "@babel/plugin-transform-classes": "7.0.0-beta.46",
         "@babel/plugin-transform-computed-properties": "7.0.0-beta.46",
         "@babel/plugin-transform-destructuring": "7.0.0-beta.46",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.46",
         "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.46",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.46",
         "@babel/plugin-transform-for-of": "7.0.0-beta.46",
         "@babel/plugin-transform-function-name": "7.0.0-beta.46",
-        "@babel/plugin-transform-instanceof": "7.0.0-beta.46",
         "@babel/plugin-transform-literals": "7.0.0-beta.46",
         "@babel/plugin-transform-modules-amd": "7.0.0-beta.46",
         "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.46",
         "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.46",
         "@babel/plugin-transform-modules-umd": "7.0.0-beta.46",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.46",
         "@babel/plugin-transform-object-super": "7.0.0-beta.46",
         "@babel/plugin-transform-parameters": "7.0.0-beta.46",
         "@babel/plugin-transform-regenerator": "7.0.0-beta.46",
@@ -802,7 +769,10 @@
         "@babel/plugin-transform-sticky-regex": "7.0.0-beta.46",
         "@babel/plugin-transform-template-literals": "7.0.0-beta.46",
         "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.46",
-        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.46"
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.46",
+        "browserslist": "3.2.6",
+        "invariant": "2.2.4",
+        "semver": "5.5.0"
       }
     },
     "@babel/preset-react": {
@@ -817,21 +787,6 @@
         "@babel/plugin-transform-react-jsx": "7.0.0-beta.46",
         "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.46",
         "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.46"
-      }
-    },
-    "@babel/preset-stage-2": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/preset-stage-2/-/preset-stage-2-7.0.0-beta.46.tgz",
-      "integrity": "sha512-Lebdh+/WyFdT+G9LaSUpcXb3ZhvQfSxd/UqjQw4iaHS1j8nKWblTZBTp6ZGHjtfvbO64ERu8EtkYJ+WelzUK7Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-proposal-decorators": "7.0.0-beta.46",
-        "@babel/plugin-proposal-export-namespace-from": "7.0.0-beta.46",
-        "@babel/plugin-proposal-function-sent": "7.0.0-beta.46",
-        "@babel/plugin-proposal-numeric-separator": "7.0.0-beta.46",
-        "@babel/plugin-proposal-throw-expressions": "7.0.0-beta.46",
-        "@babel/preset-stage-3": "7.0.0-beta.46"
       }
     },
     "@babel/preset-stage-3": {
@@ -1912,6 +1867,16 @@
         "pako": "1.0.6"
       }
     },
+    "browserslist": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.6.tgz",
+      "integrity": "sha512-XCsMSg9V4S1VRdcp265dJ+8kBRjfuFXcavbisY7G6T9QI0H1Z24PP53vvs0WDYWqm38Mco1ILDtafcS8ZR4xiw==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000833",
+        "electron-to-chromium": "1.3.45"
+      }
+    },
     "browserstack": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.0.tgz",
@@ -2114,6 +2079,12 @@
           "dev": true
         }
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000833",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000833.tgz",
+      "integrity": "sha512-tKNuKu4WLImh4NxoTgntxFpDrRiA0Q6Q1NycNhuMST0Kx+Pt8YnRDW6V8xsyH6AtO2CpAoibatEk5eaEhP3O1g==",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -3158,6 +3129,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.45",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
+      "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g=",
       "dev": true
     },
     "elliptic": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.46",
     "@babel/core": "^7.0.0-beta.46",
+    "@babel/plugin-transform-modules-commonjs": "^7.0.0-beta.46",
     "@babel/polyfill": "^7.0.0-beta.46",
-    "@babel/preset-es2015": "^7.0.0-beta.46",
+    "@babel/preset-env": "^7.0.0-beta.46",
     "@babel/preset-react": "^7.0.0-beta.46",
-    "@babel/preset-stage-2": "^7.0.0-beta.46",
+    "@babel/preset-stage-3": "^7.0.0-beta.46",
     "@babel/register": "^7.0.0-beta.46",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^8.0.0-beta.2",
@@ -58,14 +59,14 @@
   ],
   "scripts": {
     "clean": "rimraf lib dist",
-    "build": "cross-env BABEL_ENV=rollup rollup -c",
-    "dev": "cross-env BABEL_ENV=tests NODE_ENV=development webpack-dev-server",
-    "dev-ie8": "cross-env BABEL_ENV=tests NODE_ENV=development webpack-dev-server --inline=false",
+    "build": "rollup -c",
+    "dev": "cross-env BABEL_ENV=test NODE_ENV=development webpack-dev-server",
+    "dev-ie8": "cross-env BABEL_ENV=test NODE_ENV=development webpack-dev-server --inline=false",
     "prepare": "npm test && npm run clean && npm run build",
     "test": "npm run build && npm run test:input && npm run test:server-render && npm run test:build",
-    "test:input": "cross-env BABEL_ENV=tests karma start",
-    "test:server-render": "cross-env BABEL_ENV=tests mocha --require @babel/register ./tests/server-render",
-    "test:build": "cross-env BABEL_ENV=tests mocha --require @babel/register ./tests/build"
+    "test:input": "cross-env BABEL_ENV=test karma start",
+    "test:server-render": "cross-env BABEL_ENV=test mocha --require @babel/register ./tests/server-render",
+    "test:build": "cross-env BABEL_ENV=test mocha --require @babel/register ./tests/build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Replaced `es2015` preset (which is deprecated) with `env`

Renamed `tests` env to `test` as more widely used and considered as
default in some tools (for example jest).

Added commonjs babel plugin to not treat it as loose. Modules should be
handled as strict as possible.

Upgraded to stage-3 since stage-2 features are not used.

Even the size is reduced. Probably because of `env` preset.