### PR TITLE
Add noSpaceBetweenChars option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Use `inputRef` instead of `ref` if you need input node to manage focus, selectio
 ## Experimental :fire:
 The following props are considered experimental because they are more prone to issues and are likely to be changed in the future. Use with caution.
 
+### `noSpaceBetweenChars`: `boolean`
+Enforce no spacing between chars. For example, if you have:
+
+```
+<Input mask="+1 (999) 999-9999" maskChar="_" noSpaceBetweenChars={true} />
+```
+
+and someone inputs `+1 (__1) ___-____`, the field will be forced to `+1 (1__) ___-____`.
+
+Defaults to `false`.
+
 ### `beforeMaskedValueChange` : `function`
 In case you need to implement more complex masking behavior, you can provide `beforeMaskedValueChange` function to change masked value and cursor position before it will be applied to the input. `beforeMaskedValueChange` receives following arguments:
 1. **newState** (object): New input state. Contains `value` and `selection` fields. `selection` is null on input blur or when function is called before input mount. Example: `{ value: '12/1_/____', selection: { start: 4, end: 4 } }`

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -251,3 +251,53 @@ export function getRightEditablePosition(maskOptions, pos) {
 export function getStringValue(value) {
   return !value && value !== 0 ? '' : value + '';
 }
+
+function getMaskablePositions(maskOptions) {
+  const positions = [];
+  const { mask } = maskOptions;
+  const formatChars = Object.keys(maskOptions.formatChars);
+
+  for (let i = 0; i < mask.length; i++) {
+    for (let j = 0; j < formatChars.length; j++) {
+      if (mask[i] === formatChars[j]) {
+        positions.push(i);
+        break;
+      }
+    }
+  }
+
+  return positions;
+}
+
+export function collapseSpaceBetweenChars(value, currentSelection, maskOptions) {
+  const positions = getMaskablePositions(maskOptions);
+  const valueChars = value.split('');
+
+  const editableValue = positions
+    .map(index => valueChars[index])
+    .join('')
+
+  const collapsedValue = editableValue
+    .replace(new RegExp(maskOptions.maskChar, 'g'), '');
+
+  let newSelection
+
+  for (let i = 0; i < positions.length; i++) {
+    const index = positions[i];
+
+    if (collapsedValue[i]) {
+      valueChars[index] = collapsedValue[i];
+    } else {
+      valueChars[index] = maskOptions.maskChar;
+      newSelection = newSelection || { start: index, end: index };
+    }
+  }
+
+  const newValue = valueChars.join('');
+  const selectionNeedsChange = value !== newValue;
+
+  return {
+    value: valueChars.join(''),
+    selection: selectionNeedsChange ? newSelection : currentSelection
+  }
+}

--- a/tests/input/input.js
+++ b/tests/input/input.js
@@ -141,6 +141,19 @@ const TestFunctionalInputComponent = (props) => {
 };
 
 describe('react-input-mask', () => {
+  describe('with noSpaceBetweenChars', () => {
+    it('should collapse space between chars if the cursor is ahead', createInput(
+      <Input maskChar="_" noSpaceBetweenChars={true} mask="+1 (999) 999-9999" />, (input, inputNode) => {
+        inputNode.focus();
+        TestUtils.Simulate.focus(inputNode);
+
+        setInputSelection(inputNode, 6, 0);
+        simulateInputKeyPress(input, '5');
+
+        expect(inputNode.value).to.equal('+1 (5__) ___-____');
+      }));
+  });
+
   it('should format value on mount', createInput(
     <Input mask="+7 (999) 999 99 99" defaultValue="74953156454" />, (input, inputNode) => {
       expect(inputNode.value).to.equal('+7 (495) 315 64 54');


### PR DESCRIPTION
@sanniassin Here is my first pass at this. I tried to get Mocha set up for writing fast unit tests, but I was beating my head against getting `import` statements to work in the Mocha tests. I didn't really want to mess with your babel-env too much, but I think it would be good to be able to easily unit test `src/utils`, since they tend to do some important lifting.

Closes #155 