### PR TITLE
Prevent "findDOMNode is deprecated" error

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/react-input-mask.js": {
-    "bundled": 38441,
-    "minified": 13753,
-    "gzipped": 4802
+    "bundled": 38209,
+    "minified": 13649,
+    "gzipped": 4766
   },
   "lib/react-input-mask.development.js": {
-    "bundled": 34262,
-    "minified": 14847,
-    "gzipped": 4678
+    "bundled": 34061,
+    "minified": 14705,
+    "gzipped": 4644
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import invariant from 'invariant';
 import warning from 'warning';
 
@@ -27,6 +26,8 @@ class InputElement extends React.Component {
 
   constructor(props) {
     super(props);
+
+    this.handleRef = React.createRef()
 
     const { mask, maskChar, formatChars, alwaysShowMask, beforeMaskedValueChange } = props;
     let { defaultValue, value } = props;
@@ -206,7 +207,7 @@ class InputElement extends React.Component {
       return null;
     }
 
-    let input = findDOMNode(this);
+    let input = this.handleRef && this.handleRef.current;
     const isDOMNode = typeof window !== 'undefined'
                       &&
                       input instanceof window.Element;
@@ -537,12 +538,6 @@ class InputElement extends React.Component {
         selection: this.getSelection()
       };
       this.setInputValue('');
-    }
-  }
-
-  handleRef = (ref) => {
-    if (this.props.children == null && isFunction(this.props.inputRef)) {
-      this.props.inputRef(ref);
     }
   }
 


### PR DESCRIPTION
Prevent "findDOMNode is deprecated" error like React docs: https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage

<img width="885" alt="Captura de Tela 2021-01-04 às 16 25 55" src="https://user-images.githubusercontent.com/10811020/103571377-87388580-4ea9-11eb-89a1-5e3c207f6ad7.png">
