### PR TITLE
Bugfix/prevent loss of reference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,11 +268,11 @@ const InputMask = forwardRef(function InputMask(props, forwardedRef) {
     onChange: isMasked && isEditable ? onChange : props.onChange,
     onMouseDown: isMasked && isEditable ? onMouseDown : props.onMouseDown,
     ref: ref => {
-      inputRef.current = findDOMNode(ref);
+      if (ref) inputRef.current = findDOMNode(ref);
 
-      if (isFunction(forwardedRef)) {
+      if (ref && isFunction(forwardedRef)) {
         forwardedRef(ref);
-      } else if (forwardedRef !== null && typeof forwardedRef === "object") {
+      } else if (ref && forwardedRef !== null && typeof forwardedRef === "object") {
         forwardedRef.current = ref;
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -268,12 +268,14 @@ const InputMask = forwardRef(function InputMask(props, forwardedRef) {
     onChange: isMasked && isEditable ? onChange : props.onChange,
     onMouseDown: isMasked && isEditable ? onMouseDown : props.onMouseDown,
     ref: ref => {
-      if (ref) inputRef.current = findDOMNode(ref);
+      if (ref) {
+        inputRef.current = findDOMNode(ref);
 
-      if (ref && isFunction(forwardedRef)) {
-        forwardedRef(ref);
-      } else if (ref && forwardedRef !== null && typeof forwardedRef === "object") {
-        forwardedRef.current = ref;
+        if (isFunction(forwardedRef)) {
+          forwardedRef(ref);
+        } else if (forwardedRef !== null && typeof forwardedRef === "object") {
+          forwardedRef.current = ref;
+        }
       }
     },
     value: isMasked && isControlled ? lastValue : props.value


### PR DESCRIPTION
This merge request is intended to fix an insidious bug caused by a loss of reference to the input DOM element under certain circumstances.
In concreto, when the input loses focus, i.e. on blur, in response to an action which causes a re-render of the component, the input (momentarily) loses its reference: the re-render causes the ref function invoked by React.createElement to re-initialise, passing a null object on first render. At the moment, this causes both the inputRef and the forwardedRef to be set to null.

In between the first render and the second invocation of the React.createElement ref function, onBlur (and the useValue function) is called on a null inputRef, causing a crash.

A simple fix is checking for the existence of the reference returned by the ref callback.