### PR TITLE
Bugfix remove deprecated findDOMNode method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import React, { useLayoutEffect, forwardRef } from "react";
-import { findDOMNode } from "react-dom";
 import PropTypes from "prop-types";
 
 import { useInputState, useInputElement, usePrevious } from "./hooks";
@@ -268,7 +267,7 @@ const InputMask = forwardRef(function InputMask(props, forwardedRef) {
     onChange: isMasked && isEditable ? onChange : props.onChange,
     onMouseDown: isMasked && isEditable ? onMouseDown : props.onMouseDown,
     ref: ref => {
-      inputRef.current = findDOMNode(ref);
+      inputRef.current = ref;
 
       if (isFunction(forwardedRef)) {
         forwardedRef(ref);


### PR DESCRIPTION
Currently, we get such a warning:

`Warning: findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of InputElement which is inside StrictMode. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node`

This problem happens because findDOMNode method deprecated. So we don't need to use it. 

This PR should solve this problem.

![image](https://user-images.githubusercontent.com/10742084/114028094-e687a680-9899-11eb-8ab1-ed78dcd700a1.png)
